### PR TITLE
Added boost_signals fix

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -56,6 +56,11 @@ build() {
 	source /usr/share/ros-build-tools/clear-ros-env.sh
 	[ -f /opt/ros/melodic/setup.bash ] && source /opt/ros/melodic/setup.bash
 
+	# Fix boost_signals error
+        cd geometry-release-release-melodic-tf-1.12.0-0/
+        rm -rf CMakeLists.txt
+        wget https://raw.githubusercontent.com/ros/geometry/melodic-devel/tf/CMakeLists.txt
+
 	# Create the build directory.
 	[ -d ${srcdir}/build ] || mkdir ${srcdir}/build
 	cd ${srcdir}/build

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -57,7 +57,7 @@ build() {
 	[ -f /opt/ros/melodic/setup.bash ] && source /opt/ros/melodic/setup.bash
 
 	# Fix boost_signals error
-        cd geometry-release-release-melodic-tf-1.12.0-0/
+        cd ${_dir}
         rm -rf CMakeLists.txt
         wget https://raw.githubusercontent.com/ros/geometry/melodic-devel/tf/CMakeLists.txt
 


### PR DESCRIPTION
Cause boost_signals as removed from recent boost releases, there's a fix to use latest CMakeLists.txt from official TF repo.